### PR TITLE
Add Optional Debug Option To Scan Action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 hs_err_pid*
 
 .idea
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:latest
 
 RUN apt-get update && apt-get install -y curl  \
-    && curl --location -O https://pkg.contrastsecurity.com/artifactory/cli/1.0.18/linux/contrast \
+    && curl --location -O https://pkg.contrastsecurity.com/artifactory/cli/1.0.21/linux/contrast \
     && chmod +x contrast && mv contrast /usr/bin
 
 COPY entrypoint.sh /entrypoint.sh

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
   fail:
     description: 'When set to true, fails the action if CVEs have been detected that match at least the severity option specified.'
     required: false
+  debug:
+    description: 'When set to true, enables verbose/debug output.'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/contrastscan-action.iml
+++ b/contrastscan-action.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/contrastscan-action.iml
+++ b/contrastscan-action.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,12 @@ echo "Artifact: $INPUT_ARTIFACT"
 echo "Language: $INPUT_LANGUAGE"
 echo "Timeout: $INPUT_TIMEOUT"
 
+pwd
+ls -la .
+ls -la "$INPUT_ARTIFACT"
+
 [ -z "$INPUT_ORGID" ] && echo "Organization ID is required but not present" && exit 1;
-[ -z "$INPUT_ARTIFACT" ] && echo "Artifact is required but not present" && exit 1;
+[ -f "$INPUT_ARTIFACT" ] && echo "Artifact is required but not present/found" && exit 1;
 [ -z "$INPUT_APIKEY" ] && echo "Contrast API Key is required but not present" && exit 1;
 [ -z "$INPUT_AUTHHEADER" ] && echo "Contrast Authorization Header is required but not present" && exit 1;
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -l
+#!/bin/bash -lx
 
 echo "Org ID: $INPUT_ORGID"
 echo "Project Name: $INPUT_PROJECTNAME"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,13 +41,11 @@ export CODESEC_INVOCATION_ENVIRONMENT="GITHUB"
  ${INPUT_PROJECTID:+"--project-id"} ${INPUT_PROJECTID:+"$INPUT_PROJECTID"}  \
  ${INPUT_LANGUAGE:+"--language"} ${INPUT_LANGUAGE:+"$INPUT_LANGUAGE"}  \
  ${FAIL:+"--fail"} ${INPUT_SEVERITY:+"--severity"} ${INPUT_SEVERITY:+"$INPUT_SEVERITY"}  \
- --timeout "${INPUT_TIMEOUT}" -s sarif --verbose --debug 1>&1 2>&1 | tee /tmp/out
+ --timeout "${INPUT_TIMEOUT}" -s sarif --verbose --debug 1>&1 2>&1
 
  CONTRAST_RET_VAL=$?
  if [ $CONTRAST_RET_VAL -ne 0 ] && [ $CONTRAST_RET_VAL -ne 2 ]; then
      echo "An error occurred while executing the Scan. Please contact support."
  fi
-
-cat /tmp/out
 
 exit $CONTRAST_RET_VAL

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,14 +8,14 @@ echo "Artifact: $INPUT_ARTIFACT"
 echo "Language: $INPUT_LANGUAGE"
 echo "Timeout: $INPUT_TIMEOUT"
 
+[ -z "$INPUT_ORGID" ] && echo "Organization ID is required but not present" && exit 1;
+[ -z "$INPUT_ARTIFACT" ] && echo "Artifact is required but not present/found" && exit 1;
+[ -z "$INPUT_APIKEY" ] && echo "Contrast API Key is required but not present" && exit 1;
+[ -z "$INPUT_AUTHHEADER" ] && echo "Contrast Authorization Header is required but not present" && exit 1;
+
 pwd
 ls -la .
 ls -la "$INPUT_ARTIFACT"
-
-[ -z "$INPUT_ORGID" ] && echo "Organization ID is required but not present" && exit 1;
-[ -f "$INPUT_ARTIFACT" ] && echo "Artifact is required but not present/found" && exit 1;
-[ -z "$INPUT_APIKEY" ] && echo "Contrast API Key is required but not present" && exit 1;
-[ -z "$INPUT_AUTHHEADER" ] && echo "Contrast Authorization Header is required but not present" && exit 1;
 
 if [ -n "$INPUT_SEVERITY" ]
 then
@@ -40,7 +40,7 @@ export CODESEC_INVOCATION_ENVIRONMENT="GITHUB"
  ${INPUT_PROJECTID:+"--project-id"} ${INPUT_PROJECTID:+"$INPUT_PROJECTID"}  \
  ${INPUT_LANGUAGE:+"--language"} ${INPUT_LANGUAGE:+"$INPUT_LANGUAGE"}  \
  ${FAIL:+"--fail"} ${INPUT_SEVERITY:+"--severity"} ${INPUT_SEVERITY:+"$INPUT_SEVERITY"}  \
- --timeout "${INPUT_TIMEOUT}" -s sarif
+ --timeout "${INPUT_TIMEOUT}" -s sarif 1>&1 2>&1
 
  CONTRAST_RET_VAL=$?
  if [ $CONTRAST_RET_VAL -ne 0 ] && [ $CONTRAST_RET_VAL -ne 2 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,7 @@ echo "Timeout: $INPUT_TIMEOUT"
 [ -z "$INPUT_APIKEY" ] && echo "Contrast API Key is required but not present" && exit 1;
 [ -z "$INPUT_AUTHHEADER" ] && echo "Contrast Authorization Header is required but not present" && exit 1;
 
+env
 pwd
 ls -la .
 ls -la "$INPUT_ARTIFACT"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -lx
+#!/bin/bash -l
 
 echo "Org ID: $INPUT_ORGID"
 echo "Project Name: $INPUT_PROJECTNAME"
@@ -7,16 +7,12 @@ echo "API URL: $INPUT_APIURL"
 echo "Artifact: $INPUT_ARTIFACT"
 echo "Language: $INPUT_LANGUAGE"
 echo "Timeout: $INPUT_TIMEOUT"
+echo "Debug: $INPUT_DEBUG"
 
 [ -z "$INPUT_ORGID" ] && echo "Organization ID is required but not present" && exit 1;
-[ -z "$INPUT_ARTIFACT" ] && echo "Artifact is required but not present/found" && exit 1;
+[ ! -f "$INPUT_ARTIFACT" ] && echo "Artifact is required but not present/found" && exit 1;
 [ -z "$INPUT_APIKEY" ] && echo "Contrast API Key is required but not present" && exit 1;
 [ -z "$INPUT_AUTHHEADER" ] && echo "Contrast Authorization Header is required but not present" && exit 1;
-
-env
-pwd
-ls -la .
-ls -la "$INPUT_ARTIFACT"
 
 if [ -n "$INPUT_SEVERITY" ]
 then
@@ -41,7 +37,8 @@ export CODESEC_INVOCATION_ENVIRONMENT="GITHUB"
  ${INPUT_PROJECTID:+"--project-id"} ${INPUT_PROJECTID:+"$INPUT_PROJECTID"}  \
  ${INPUT_LANGUAGE:+"--language"} ${INPUT_LANGUAGE:+"$INPUT_LANGUAGE"}  \
  ${FAIL:+"--fail"} ${INPUT_SEVERITY:+"--severity"} ${INPUT_SEVERITY:+"$INPUT_SEVERITY"}  \
- --timeout "${INPUT_TIMEOUT}" -s sarif --verbose --debug 1>&1 2>&1
+ ${INPUT_DEBUG:+--verbose --debug} \
+ --timeout "${INPUT_TIMEOUT}" -s sarif 1>&1 2>&1
 
  CONTRAST_RET_VAL=$?
  if [ $CONTRAST_RET_VAL -ne 0 ] && [ $CONTRAST_RET_VAL -ne 2 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,11 +41,13 @@ export CODESEC_INVOCATION_ENVIRONMENT="GITHUB"
  ${INPUT_PROJECTID:+"--project-id"} ${INPUT_PROJECTID:+"$INPUT_PROJECTID"}  \
  ${INPUT_LANGUAGE:+"--language"} ${INPUT_LANGUAGE:+"$INPUT_LANGUAGE"}  \
  ${FAIL:+"--fail"} ${INPUT_SEVERITY:+"--severity"} ${INPUT_SEVERITY:+"$INPUT_SEVERITY"}  \
- --timeout "${INPUT_TIMEOUT}" -s sarif 1>&1 2>&1
+ --timeout "${INPUT_TIMEOUT}" -s sarif --verbose --debug 1>&1 2>&1 | tee /tmp/out
 
  CONTRAST_RET_VAL=$?
  if [ $CONTRAST_RET_VAL -ne 0 ] && [ $CONTRAST_RET_VAL -ne 2 ]; then
      echo "An error occurred while executing the Scan. Please contact support."
  fi
+
+cat /tmp/out
 
 exit $CONTRAST_RET_VAL


### PR DESCRIPTION
Upgrading to latest contrastscan action for Authz was painful due to lack of information - see https://github.com/Contrast-Security-Inc/platform-authz-service/pull/149

Normal execution: 
```
$ docker run --platform linux/amd64 --workdir /github/workspace -e INPUT_ORGID=blah -e INPUT_ARTIFACT=authz-app/target/authz-app-0.0.86-SNAPSHOT.jar -e INPUT_APIKEY=blah -e INPUT_AUTHHEADER=blah  -e INPUT_TIMEOUT=300 -e INPUT_APIURL=https://teamserver-harmony-dev.contsec.com/Contrast -v ~/git/platform-authz-service:/github/workspace scan:2.0.5
Org ID: blah
Project Name:
Project ID:
API URL: https://teamserver-harmony-dev.contsec.com/Contrast
Artifact: authz-app/target/authz-app-0.0.86-SNAPSHOT.jar
Language:
Timeout: 300
Debug:
- Uploading file to scan.
Contrast Scan Finished
An error occurred while executing the Scan. Please contact support.
```
🤷 

With debug:
```
$ docker run --platform linux/amd64 --workdir /github/workspace -e INPUT_ORGID=blah -e INPUT_ARTIFACT=authz-app/target/authz-app-0.0.86-SNAPSHOT.jar -e INPUT_APIKEY=blah -e INPUT_AUTHHEADER=blah  -e INPUT_DEBUG=true -e INPUT_TIMEOUT=300 -e INPUT_APIURL=https://teamserver-harmony-dev.contsec.com/Contrast -v ~/git/platform-authz-service:/github/workspace scan:2.0.5
Org ID: blah
Project Name:
Project ID:
API URL: https://teamserver-harmony-dev.contsec.com/Contrast
Artifact: authz-app/target/authz-app-0.0.86-SNAPSHOT.jar
Language:
Timeout: 300
Debug: true
- Uploading file to scan.
{
  apiKey: 'blah',
  authorization: 'blah',
  host: 'https://teamserver-harmony-dev.contsec.com/Contrast',
  organizationId: 'blah',
  file: 'authz-app/target/authz-app-0.0.86-SNAPSHOT.jar',
  verbose: true,
  debug: true,
  timeout: 300,
  save: 'sarif',
  name: 'authz-app-0.0.86-SNAPSHOT.jar',
  projectNameSource: 'AUTO',
  projectId: undefined
}
✖ Unable to upload the file.
returned with status code 302
Contrast Scan Finished
An error occurred while executing the Scan. Please contact support.
```