### PR TITLE
EE-262 - Broken timeout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,9 +27,9 @@ inputs:
     description: 'The language of your project.'
     required: false
   timeout:
-    description: 'Set a specific time span (in seconds) before the function times out. The default timeout is 5 minutes if timeout is not set.'
+    description: 'Set a specific time span (in seconds) before the function times out. The default timeout is 10 minutes if timeout is not set.'
     required: false
-    default: 300
+    default: 600
   severity:
     description: 'Allows user to report vulnerabilities above a chosen severity level. Values for level are high, medium or low. (Note: Use this input in combination with the fail input, otherwise the action will exit)'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -95,7 +95,6 @@ runs:
         echo "args=${args[@]}" >> $GITHUB_OUTPUT
 
     - name: Run Contrast Scan CLI Command
-      continue-on-error: true
       id: run-scan
       shell: bash
       run: |


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fb919c80-c848-41bf-9d55-7490f8f9d856)
We have noticed that very often our scans time out, and they appear as PASSED in the workflow when the scan wasn't actually completed on time. This affects a lot of our workflows.

This PR fixes that issue by removing continue on error and also increases default timeout to 10 mins as 5 mins is not enough for most of our services


after:
![image](https://github.com/user-attachments/assets/872e17bb-c71d-4bed-8d6d-977d17a89dff)

